### PR TITLE
[chore] #1 jacoco limit 0.3 -> 0.2 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestCoverageVerification {
 	violationRules {
 		rule {
 			limit {
-				minimum = 0.3// 최소 커버리지 비율 설정 (예: 80%)
+				minimum = 0.2// 최소 커버리지 비율 설정 (예: 80%)
 			}
 		}
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #1 

### 📝PR 설명
aws 배포중 jacoco limit이 0.3이 충족되어야 한다는데 현재 0.2라 0.2로 낮추었습니다.

### 🔨작업 내용
- [x] jacoco limit 0.3 -> 0.2

## 🖼️스크린샷 (사진 및 작업 결과)

> 

## 💬리뷰 요구사항(선택)

> 
