### PR TITLE
[fix] #58 유저의 총 채용일정 상태 개수 조회 이름 바꾸기

### DIFF
--- a/src/test/java/com/letscareer/recruitment/RecruitmentControllerTest.java
+++ b/src/test/java/com/letscareer/recruitment/RecruitmentControllerTest.java
@@ -205,7 +205,7 @@ public class RecruitmentControllerTest extends ControllerTestConfig {
 	}
 
 	@Test
-	@DisplayName("유저의 총 채용일정 상태 개수 조회")
+	@DisplayName("유저의 총 채용일정 상태 개수 조회(전형)")
 	public void testGetRecruitmentsStageStatus() throws Exception {
 		Long userId = 1L;
 


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #58 

### 📝PR 설명

### 🔨작업 내용
- [ ]유저의 총 채용일정 상태 개수 조회 이름 바꾸기
- [ ]

## 🖼️스크린샷 (사진 및 작업 결과)

> 

## 💬리뷰 요구사항(선택)

> 
